### PR TITLE
Feature/steamclientports

### DIFF
--- a/Assets/RiptideSteamTransport/Transport/SteamClient.cs
+++ b/Assets/RiptideSteamTransport/Transport/SteamClient.cs
@@ -53,10 +53,12 @@ namespace Riptide.Transports.Steam
                 return false;
             }
 
-            if (TrySplitHostAddress(hostAddress, out string _hostAddress, out int _port))
+
+            int colonIndex = hostAddress.IndexOf(':');
+            if (colonIndex != -1
+                && int.TryParse(hostAddress[(colonIndex + 1)..], out port))
             {
-                hostAddress = _hostAddress;
-                port = _port;
+                hostAddress = hostAddress[..colonIndex];
             }
 
             connectError = $"Invalid host address '{hostAddress}'! Expected '{LocalHostIP}' or '{LocalHostName}' for local connections, or a valid Steam ID.";
@@ -130,20 +132,6 @@ namespace Riptide.Transports.Steam
 
             if (!steamConnection.IsConnected)
                 OnConnectionFailed();
-        }
-
-        private static bool TrySplitHostAddress(string hostAddress, out string address, out int port)
-        {
-            int colonIndex = hostAddress.IndexOf(':');
-            if (colonIndex == -1)
-            {
-                address = default;
-                port = default;
-                return false;
-            }
-
-            address = hostAddress[..colonIndex];
-            return int.TryParse(hostAddress[(colonIndex + 1)..], out port);
         }
 
         private void OnConnectionStatusChanged(SteamNetConnectionStatusChangedCallback_t callback)

--- a/Assets/RiptideSteamTransport/Transport/SteamClient.cs
+++ b/Assets/RiptideSteamTransport/Transport/SteamClient.cs
@@ -55,9 +55,13 @@ namespace Riptide.Transports.Steam
 
 
             int colonIndex = hostAddress.IndexOf(':');
-            if (colonIndex != -1
-                && int.TryParse(hostAddress[(colonIndex + 1)..], out port))
+            if (colonIndex != -1)
             {
+                if (!int.TryParse(hostAddress[(colonIndex + 1)..], out port))
+                {
+                    connectError = $"Couldn't connect: Failed to parse port '{hostAddress[(colonIndex + 1)..]}'";
+                    return false;
+                }
                 hostAddress = hostAddress[..colonIndex];
             }
 

--- a/Assets/RiptideSteamTransport/Transport/SteamClient.cs
+++ b/Assets/RiptideSteamTransport/Transport/SteamClient.cs
@@ -53,16 +53,15 @@ namespace Riptide.Transports.Steam
                 return false;
             }
 
-
-            int colonIndex = hostAddress.IndexOf(':');
-            if (colonIndex != -1)
+            int portSeperatorIndex = hostAddress.IndexOf(':');
+            if (portSeperatorIndex != -1)
             {
-                if (!int.TryParse(hostAddress[(colonIndex + 1)..], out port))
+                if (!int.TryParse(hostAddress[(portSeperatorIndex + 1)..], out port))
                 {
-                    connectError = $"Couldn't connect: Failed to parse port '{hostAddress[(colonIndex + 1)..]}'";
+                    connectError = $"Couldn't connect: Failed to parse port '{hostAddress[(portSeperatorIndex + 1)..]}'";
                     return false;
                 }
-                hostAddress = hostAddress[..colonIndex];
+                hostAddress = hostAddress[..portSeperatorIndex];
             }
 
             connectError = $"Invalid host address '{hostAddress}'! Expected '{LocalHostIP}' or '{LocalHostName}' for local connections, or a valid Steam ID.";

--- a/Assets/RiptideSteamTransport/Transport/SteamClient.cs
+++ b/Assets/RiptideSteamTransport/Transport/SteamClient.cs
@@ -53,17 +53,6 @@ namespace Riptide.Transports.Steam
                 return false;
             }
 
-            int portSeperatorIndex = hostAddress.IndexOf(':');
-            if (portSeperatorIndex != -1)
-            {
-                if (!int.TryParse(hostAddress[(portSeperatorIndex + 1)..], out port))
-                {
-                    connectError = $"Couldn't connect: Failed to parse port '{hostAddress[(portSeperatorIndex + 1)..]}'";
-                    return false;
-                }
-                hostAddress = hostAddress[..portSeperatorIndex];
-            }
-
             connectError = $"Invalid host address '{hostAddress}'! Expected '{LocalHostIP}' or '{LocalHostName}' for local connections, or a valid Steam ID.";
             if (hostAddress == LocalHostIP || hostAddress == LocalHostName)
             {
@@ -77,7 +66,19 @@ namespace Riptide.Transports.Steam
                 connection = steamConnection = ConnectLocal();
                 return true;
             }
-            else if (ulong.TryParse(hostAddress, out ulong hostId))
+
+            int portSeperatorIndex = hostAddress.IndexOf(':');
+            if (portSeperatorIndex != -1)
+            {
+                if (!int.TryParse(hostAddress[(portSeperatorIndex + 1)..], out port))
+                {
+                    connectError = $"Couldn't connect: Failed to parse port '{hostAddress[(portSeperatorIndex + 1)..]}'";
+                    return false;
+                }
+                hostAddress = hostAddress[..portSeperatorIndex];
+            }
+
+            if (ulong.TryParse(hostAddress, out ulong hostId))
             {
                 connection = steamConnection = TryConnect(new CSteamID(hostId), port);
                 return connection != null;


### PR DESCRIPTION
SteamServer.Start(ushort port) accepts a port. but SteamClient is hard-coded to use the port zero. 

now, hostAddress can optionally be of format `<SteamId>:<port>`. behavior unchanged for a plain SteamId (use port zero)